### PR TITLE
fix: un-break Upptime (node24 action bump) and slash uptime cron to hourly

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -33,20 +33,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "readme"
         env:
@@ -57,7 +57,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "readme"
         env:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -17,7 +17,7 @@
 name: Uptime CI
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "0 * * * *"
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "update"
         env:


### PR DESCRIPTION
## Why

Every Actions run in this repo has **failed since 2026-06-08**. Two causes:

1. **Node runtime break (fixed here).** GitHub retired the `node20` action runtime. The pinned `upptime/uptime-monitor@v1.41.0` (`using: node20`, `node-libcurl@4` / `NODE_MODULE_VERSION 115`) is now force-run on node24 (`NMV 137`), so its native module can't load — the run dies before checking anything.
2. **Write path (needs a repo secret — see below).** There is no `GH_PAT` secret set, so the action falls back to `github.token`, which is `read`-only. The push 403s. Granting the default token write is **blocked by enterprise policy**, so a PAT is required.

## What this PR does

- Bumps `upptime/uptime-monitor` `v1.41.0 → v1.43.12` (`using: node24`, `node-libcurl@5`) across all workflows. **Verified on this branch:** the monitor now loads and checks all three sites (`nevermined.ai`, `nevermined.app`, `nevermined.ai/docs`) → all `up`.
- Cuts `uptime.yml` schedule `*/5 * * * *` → `0 * * * *` (hourly). `*/5` was already throttled to ~hourly on this public repo; hourly is honest, reliable, and plenty for 3 URLs. Bump to `*/15` if faster outage detection is wanted.

Public repo ⇒ these runs are free/unbilled regardless; this cuts run *volume* and, more importantly, un-breaks the monitor.

## ⚠️ Follow-up required to restore write-back (status page / badges / history)

The monitor runs after this PR, but still can't commit results until a token with `contents: write` on this repo is added as the **`GH_PAT`** Actions secret (classic PAT `repo` scope, or a fine-grained token scoped to this repo). The tokenless `GITHUB_TOKEN` path is disabled by enterprise policy. Once `GH_PAT` is set, every workflow goes green with no further code changes.