### PR TITLE
fix: correct repo/baseUrl so the status page renders

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -1,6 +1,6 @@
 # Change these first
 owner: nevermined-io # Your GitHub organization or username, where this repository lives
-repo: upptime # The name of this repository
+repo: uptime # The name of this repository
 
 sites:
   - name: Nevermined Website
@@ -14,7 +14,7 @@ status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there
   #cname: demo.upptime.js.org
-  baseUrl: /upptime
+  baseUrl: /uptime
   logoUrl: https://raw.githubusercontent.com/nevermined-io/assets/refs/heads/main/images/app/dashboard-logo.svg
   name: Nevermined
   introTitle: "**Nevermined Status**"


### PR DESCRIPTION
`.upptimerc.yml` had the template placeholder `upptime` instead of the real repo name `uptime`, so the gh-pages SPA loaded its JS from `/upptime/...` (404) and rendered blank. Corrects `repo` and `baseUrl` to `uptime` / `/uptime`. Site rebuild (site.yml) redeploys the corrected assets.