### PR TITLE
feat: white status page + compact nevermined.ai header

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -13,22 +13,27 @@ sites:
 status-website:
   baseUrl: /uptime
   logoUrl: https://raw.githubusercontent.com/nevermined-io/assets/refs/heads/main/images/app/logo.svg
+  logoHref: https://nevermined.ai
+  hideNavTitle: true
   favicon: https://raw.githubusercontent.com/nevermined-io/assets/refs/heads/main/images/app/favicon.png
   name: Nevermined
   introTitle: "**Nevermined Status**"
   introMessage: Real-time status of Nevermined applications and services
-  theme: dark
+  theme: light
   navbar:
     - title: Status
       href: /
-    - title: Website
-      href: https://nevermined.ai
+    - title: Docs
+      href: https://nevermined.ai/docs
     - title: GitHub
       href: https://github.com/$OWNER/$REPO
-  # Nevermined brand skin. Upptime themes are 100% CSS-variable driven (global.css
-  # reads var(--x), dark.css sets them). customHeadHtml is injected into <head>
-  # BEFORE dark.css, so overrides use !important to win the cascade.
-  # Palette from nevermined.ai-website: teal #0d3f48, lime #bcdc4a, gradient #bcdc4a->#abe2dd.
+    - title: nevermined.ai
+      href: https://nevermined.ai
+  # White page + a compact nevermined.ai-style header. Upptime themes are CSS-variable
+  # driven; customHeadHtml injects a <style> BEFORE the theme css, so overrides use
+  # !important. Header = the Upptime <nav> restyled into the website's teal bar
+  # (white wordmark, lime hover, gradient CTA pill on the last link). Content aligns
+  # with the header because both share the 800px .container.
   customHeadHtml: |
     <meta name="theme-color" content="#0d3f48" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -36,43 +41,89 @@ status-website:
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
     <style>
       :root {
-        --body-background-color: #0a2b31 !important;
-        --body-text-color: #eaf5f2 !important;
-        --card-background-color: #0d3f48 !important;
-        --card-border-color: #285f62 !important;
-        --nav-background-color: #0b353c !important;
-        --nav-border-bottom-color: #285f62 !important;
-        --nav-current-border-bottom-color: #bcdc4a !important;
+        --body-background-color: #ffffff !important;
+        --body-text-color: #14343a !important;
+        --card-background-color: #ffffff !important;
+        --card-border-color: #e2e6ec !important;
+        --nav-background-color: #0d3f48 !important;
+        --nav-border-bottom-color: #0d3f48 !important;
+        --nav-current-border-bottom-color: transparent !important;
         --up-border-left-color: #bcdc4a !important;
-        --up-color-color: #bcdc4a !important;
+        --up-color-color: #5b7516 !important;
         --tag-color: #0d3f48 !important;
         --tag-up-background-color: #bcdc4a !important;
         --tag-down-background-color: #eb3b5a !important;
         --tag-degraded-background-color: #f7b731 !important;
-        --down-border-left-color: #ff5c78 !important;
+        --down-border-left-color: #eb3b5a !important;
         --degraded-border-left-color: #f7b731 !important;
-        --submit-button-background-color: #bcdc4a !important;
-        --submit-button-color: #0d3f48 !important;
-        --submit-button-border-color: #bcdc4a !important;
+        --submit-button-background-color: #0d3f48 !important;
+        --submit-button-color: #ffffff !important;
+        --submit-button-border-color: #0d3f48 !important;
         --error-button-background-color: #bcdc4a !important;
         --error-button-color: #0d3f48 !important;
         --error-button-border-color: #bcdc4a !important;
       }
       body {
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
-        background: linear-gradient(180deg, #0d3f48 0%, #0a2b31 55%, #08252a 100%) !important;
-        background-attachment: fixed !important;
+        background: #ffffff !important;
+        color: #14343a !important;
       }
       button, input, select, textarea { font-family: 'Inter', sans-serif !important; }
-      a { color: #bcdc4a !important; }
+
+      /* ---- nevermined.ai-style header bar ---- */
+      nav {
+        background: #0d3f48 !important;
+        padding: 0 !important;
+        margin: 0 0 2.75rem 0 !important;
+        position: sticky !important;
+        top: 0 !important;
+        z-index: 100 !important;
+        box-shadow: 0 1px 10px rgba(13, 63, 72, 0.14) !important;
+      }
+      nav .container { min-height: 56px !important; }
+      nav a.logo { padding: 0 !important; margin-right: 1.5rem !important; }
+      nav a.logo img { height: 22px !important; margin: 0 !important; border-radius: 0 !important; }
+      nav ul li a {
+        padding: 0.5rem 0 !important;
+        margin: 0 0 0 1.4rem !important;
+        color: rgba(255, 255, 255, 0.78) !important;
+        font-size: 0.95rem !important;
+        font-weight: 400 !important;
+        transition: color 0.2s ease !important;
+      }
+      nav ul li a:hover { color: #bcdc4a !important; }
+      nav ul li a[aria-current="page"] { color: #ffffff !important; font-weight: 600 !important; }
+      nav ul li:last-child a {
+        background: linear-gradient(90deg, #bbdc4b 0%, #83ddd8 100%) !important;
+        color: #0a2224 !important;
+        border-radius: 9999px !important;
+        padding: 0.5rem 1.15rem !important;
+        margin-left: 1.4rem !important;
+        font-weight: 700 !important;
+        transition: box-shadow 0.2s ease, transform 0.2s ease !important;
+      }
+      nav ul li:last-child a:hover {
+        color: #0a2224 !important;
+        box-shadow: 0 0 14px rgba(187, 220, 75, 0.4) !important;
+        transform: translateY(-1px) !important;
+      }
+
+      /* ---- content on white ---- */
       header h1, header h1 strong {
-        background: linear-gradient(120deg, #bcdc4a 0%, #abe2dd 100%) !important;
-        -webkit-background-clip: text !important;
-        background-clip: text !important;
-        -webkit-text-fill-color: transparent !important;
-        color: transparent !important;
+        background: none !important;
+        -webkit-background-clip: border-box !important;
+        background-clip: border-box !important;
+        -webkit-text-fill-color: #0d3f48 !important;
+        color: #0d3f48 !important;
         font-weight: 700 !important;
         letter-spacing: -0.02em !important;
       }
-      header p.lead { color: #9fc9c2 !important; }
+      header p.lead { color: #5c6b6b !important; }
+      section + h2 { color: #0d3f48 !important; }
+      a { color: #277577 !important; }
+      article {
+        border-radius: 12px !important;
+        box-shadow: 0 1px 3px rgba(13, 63, 72, 0.06), 0 4px 16px rgba(13, 63, 72, 0.05) !important;
+      }
+      article.up { border-left-width: 4px !important; }
     </style>


### PR DESCRIPTION
Per feedback: white main page with a smaller version of the website header.

- **Body → white** (`theme: light` + variable overrides), dark-teal text, solid-teal `Nevermined Status` heading
- **Header** = Upptime nav restyled into the nevermined.ai bar: teal `#0d3f48`, white wordmark, `hover:chartreuse` links, gradient CTA pill (`#bbdc4b→#83ddd8`) linking to nevermined.ai; ~56px tall (site is ~60-66px)
- Dropped the redundant nav title (`hideNavTitle`), cards are white with a light border + subtle shadow, lime kept for "up" status
- Header + content share the 800px container, so they align