### PR TITLE
chore: serve status page at status.nevermined.ai [BLOCKED on DNS]

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -11,7 +11,7 @@ sites:
     url: https://nevermined.ai/docs
 
 status-website:
-  baseUrl: /uptime
+  cname: status.nevermined.ai
   logoUrl: https://raw.githubusercontent.com/nevermined-io/assets/refs/heads/main/images/app/logo.svg
   logoHref: https://nevermined.ai
   hideNavTitle: true


### PR DESCRIPTION
**⛔ DRAFT — do not merge until `status.nevermined.ai` resolves.**

Cuts the status page over to the `status.nevermined.ai` custom domain:
- `cname: status.nevermined.ai` → Upptime writes the `CNAME` file to `gh-pages`, so GitHub serves the repo at that host
- drops `baseUrl: /uptime` → assets resolve at the custom-domain root

**Prerequisite (Namecheap, manual — `.ai` DNS is not in argocd/Cloudflare):**

| Type | Host | Value | TTL |
|------|------|-------|-----|
| CNAME | `status` | `nevermined-io.github.io` | Automatic |

**Why blocked:** merging before the CNAME resolves makes GitHub 301-redirect `github.io/uptime/` to a dead host (status page down) and blocks Let's Encrypt issuance. Once DNS is live: mark ready → merge → rebuild → set Pages custom domain + enforce HTTPS → verify.