### PR TITLE
feat: monitor sandbox + live production APIs

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -9,6 +9,10 @@ sites:
     url: https://nevermined.app
   - name: Nevermined Docs
     url: https://nevermined.ai/docs
+  - name: Nevermined API (Sandbox)
+    url: https://api.sandbox.nevermined.app/
+  - name: Nevermined API (Live)
+    url: https://api.live.nevermined.app/
 
 status-website:
   cname: status.nevermined.ai


### PR DESCRIPTION
Adds the two production API endpoints to the status page (both roots return 200, added as-is):
- `https://api.sandbox.nevermined.app/` — Nevermined API (Sandbox)
- `https://api.live.nevermined.app/` — Nevermined API (Live)